### PR TITLE
center the sponsor icons

### DIFF
--- a/src/components/LandingPages/Sponsors/Sponsors.css
+++ b/src/components/LandingPages/Sponsors/Sponsors.css
@@ -182,3 +182,7 @@ section {
   margin-right: -15px;
   margin-left: -7px;
 }
+.row_sponsors a {
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
sponsor icons are now align in center
![Screenshot 2022-10-16 092927](https://user-images.githubusercontent.com/86398394/196046978-42212368-f231-440b-bb17-699f2a1c7448.png)
